### PR TITLE
fixing restart with supervisor socket

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,12 @@
 [supervisord]
 nodaemon=true
 
+[unix_http_server]
+file=/app/supervisord.sock
+
+[supervisorctl]
+serverurl=unix:///app/supervisord.sock
+
 [program:sptserver]
 command=/app/SPT.Server.exe
 stdout_logfile=/dev/fd/1


### PR DESCRIPTION
Seems unix socket is required now so adding this.